### PR TITLE
Added name property to gamepad.js

### DIFF
--- a/src/gamepad.js
+++ b/src/gamepad.js
@@ -5,6 +5,7 @@ const gamepad = {
   init: function(gpad) {
     let gamepadPrototype = {
       id: gpad.index,
+      name: gpad.id,
       buttons: gpad.buttons.length,
       axes: Math.floor(gpad.axes.length / 2),
       axeValues: [],


### PR DESCRIPTION
Added a "name" property to gamepad-object taken from browsers gamepad.id (e.g. Xbox 360 Controller (XInput STANDARD GAMEPAD))
This should close issue #28